### PR TITLE
fix: do not add scraped files to the file repo

### DIFF
--- a/crgw-ui/src/providers/fileRepository/hook.ts
+++ b/crgw-ui/src/providers/fileRepository/hook.ts
@@ -27,11 +27,11 @@ export const useFileRepository = () => {
     dispatch!({ type: "ADD", payload: fs });
   };
 
-  const createThenAddFiles = (fs: CorganizeFile[]): Promise<CreateResponse> => {
+  const createScrapedFiles = (fs: CorganizeFile[]): Promise<CreateResponse> => {
     return getInstance()
       .createFiles(fs)
       .then(({ created, skipped }) => {
-        addFiles!([...created, ...skipped]);
+        addAll([...created, ...skipped]);
         return { created, skipped };
       });
   };
@@ -89,7 +89,7 @@ export const useFileRepository = () => {
     isMostRecentFile,
     mostRecentFile,
     addFiles,
-    createThenAddFiles,
+    createScrapedFiles,
     updateFile,
     markAsOpened,
     findById,


### PR DESCRIPTION
scraped files do not need to show up in the main grid. do not add them to the context.

however, still add them to the `globalstore.cache` so the duplicate check feature in the scrape panel continues to work.