### PR TITLE
One volume mount

### DIFF
--- a/crgw-daemon/config/config.py
+++ b/crgw-daemon/config/config.py
@@ -11,14 +11,14 @@ server:
   host: ""
   apikey: ""
 log:
-  all: /mnt/all.log
-  watcher: /mnt/watcher.log
-  cleaner: /mnt/cleaner.log
-  scraper: /mnt/scraper.log
+  all: /mnt/logs/all.log
+  watcher: /mnt/logs/watcher.log
+  cleaner: /mnt/logs/cleaner.log
+  scraper: /mnt/logs/scraper.log
 data:
-  path: /data
+  path: /mnt/data
 watch:
-  path: /watch
+  path: /mnt/downloads/complete
   watchdog:
     recursive: false
     handler:

--- a/crgw-daemon/daemon/__main__.py
+++ b/crgw-daemon/daemon/__main__.py
@@ -6,6 +6,7 @@ from time import sleep
 from typing import Callable
 
 import requests
+from requests import ConnectionError
 from commmons import init_logger_with_handlers
 from urllib3.exceptions import MaxRetryError, NewConnectionError
 
@@ -52,7 +53,7 @@ def wait_until_api_ready():
         try:
             r = requests.get("http://api/health/ready")
             status = r.status_code
-        except (MaxRetryError, ConnectionRefusedError, NewConnectionError):
+        except (MaxRetryError, ConnectionRefusedError, NewConnectionError, ConnectionError):
             status = 500
 
         if status == 200:

--- a/crgw-daemon/watcher/handler.py
+++ b/crgw-daemon/watcher/handler.py
@@ -83,16 +83,14 @@ def _handle_single_file(src_path: str, data_dir: str, cc: CorganizeClient, origi
     if len(result["created"]) > 0:
         # Copy the file to the new location
         dst_path = os.path.join(data_dir, f"{fileid}.dec")
-        shutil.copyfile(src_path, dst_path)
-        logger.info("file copied")
+        os.rename(src_path, dst_path)
+        logger.info("file moved")
 
         requests.post("http://api/files", json=[dst_path])
         logger.info("api local cache updated")
     else:
         logger.warning("fileid already exists")
-
-    logger.info("file removed")
-    os.remove(src_path)
+        os.remove(src_path)
 
 
 def handle(src_path: str, config: dict):

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -53,5 +53,3 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
       - ./mnt:/mnt
-      - ./data:/data
-      - ./watch:/watch


### PR DESCRIPTION
mounting everything as a single volume from the host device to allow `os.rename` within the daemon container