### PR TITLE
concat remuxer

### DIFF
--- a/crgw-api/crgw/postprocessing.py
+++ b/crgw-api/crgw/postprocessing.py
@@ -100,8 +100,9 @@ def trim_clip(fileid: str, segments: List[Tuple[int, int]]) -> dict:
             _subclip(source_path, segment_path, start, end)
             segment_paths.append(segment_path)
 
+        os.makedirs("/tmp", exist_ok=True)
         with open(concat_specs_path, "w") as fp:
-            fp.writelines([f"file '{p}'" for p in segment_paths])
+            fp.write("\n".join([f"file '{p}'" for p in segment_paths]))
 
         subprocess_call([
             get_moviepy_setting("FFMPEG_BINARY"), "-y",
@@ -111,9 +112,10 @@ def trim_clip(fileid: str, segments: List[Tuple[int, int]]) -> dict:
             "-c", "copy",
             tmp_path
         ])
+        os.rename(tmp_path, target_path)
 
         # Cleanup temporary files...
-        os.rename(tmp_path, target_path)
+        os.remove(concat_specs_path)
         for segment_path in segment_paths:
             os.remove(segment_path)
 

--- a/crgw-api/crgw/postprocessing.py
+++ b/crgw-api/crgw/postprocessing.py
@@ -28,6 +28,7 @@ def _subclip(source_path, target_path, start, end):
     ])
     os.rename(tmp_path, target_path)
 
+
 def _concat_clips(source_paths, target_path):
     tmp_path = target_path + ".mkv"
     concat_input_arg = "concat:" + "|".join(source_paths)
@@ -107,7 +108,6 @@ def trim_clip(fileid: str, segments: List[Tuple[int, int]]) -> dict:
             _subclip(source_path, segment_path, start, end)
             segment_paths.append(segment_path)
         return segment_paths
-
 
     def cleanup_segment_files(segment_paths: List[str]):
         for segment_path in segment_paths:


### PR DESCRIPTION
the `concat:file1|file2|file3...` syntax only worked for the mkv container which is unsupported in many browsers.

falling back to the text file to invoke the remuxer as this method works for all containers.