### PR TITLE
fix: hide inactive files

### DIFF
--- a/crgw-ui/src/clients/adapter.ts
+++ b/crgw-ui/src/clients/adapter.ts
@@ -42,7 +42,7 @@ export async function retrieveFiles(
 
   const callback = (files: CorganizeFile[]) => {
     files.forEach(decorate(localFileIndex));
-    const filtered = files.filter((f) => f.streamingurl);
+    const filtered = files.filter((f) => f.streamingurl && f.filename);
     const added = onLoad(filtered);
     count += added.length;
     return added;


### PR DESCRIPTION
When viewing 'recent' files, some files are missing `filename` and will cause the webapp to crash. This PR fixes that issue by ignoring such files.