### PR TITLE
fix: make newly reencoded files discoverable

### DIFF
--- a/crgw-api/crgw/postprocessing.py
+++ b/crgw-api/crgw/postprocessing.py
@@ -7,9 +7,11 @@ from corganizeclient.client import CorganizeClient
 from moviepy.config import get_setting as get_moviepy_setting
 from moviepy.tools import subprocess_call
 
+from crgw.local_filesystem import add_local_files
+
 DATA_PATH = "/data"
 TRIMID_LENGTH = 6
-DEFAULT_CRF = 25
+DEFAULT_CRF = 28
 
 LOGGER = logging.getLogger("crgw-api")
 
@@ -183,4 +185,5 @@ def _process(fileid: str,
     ))
 
     crg_client.create_files([new_file])
+    add_local_files([target_path])
     return new_file


### PR DESCRIPTION
newly reenoded files aren't discovered until the next scan cycle (every 30min)

this PR adds the files individually as soon as the encoding is finished.

Additionally, setting the default CRF to 28